### PR TITLE
MachineInterface::getProvider() can return null

### DIFF
--- a/src/MachineInterface.php
+++ b/src/MachineInterface.php
@@ -31,9 +31,9 @@ interface MachineInterface extends \JsonSerializable
     public function setRemoteId(int $remoteId): void;
 
     /**
-     * @return ProviderInterface::NAME_*
+     * @return ProviderInterface::NAME_*|null
      */
-    public function getProvider(): string;
+    public function getProvider(): ?string;
     public function getName(): string;
 
     /**


### PR DESCRIPTION
Fixes #18